### PR TITLE
also inject in search context menu and channel list context menu

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ module.exports = class ViewRaw extends Plugin {
 
 	pluginWillUnload() {
 		uninject('copy-link-contextmenu');
+		uninject('copy-link-searchcontextmenu');
 		uninject('copy-link-dotmenu');
 	}
 
@@ -35,18 +36,26 @@ module.exports = class ViewRaw extends Plugin {
 			}/${message.id}`;
 		}
 
+		const contextMenuFunc = (args, res) => {
+			if (!args[0]?.message) return res;
+			let url = getURL(args[0].channel, args[0].message);
+
+			checkChildren(res, url);
+
+			return res;
+		}
+
 		injectContextMenu(
 			'copy-link-contextmenu',
 			'MessageContextMenu',
-			(args, res) => {
-				if (!args[0]?.message) return res;
-				let url = getURL(args[0].channel, args[0].message);
-
-				checkChildren(res, url);
-
-				return res;
-			},
+			contextMenuFunc,
 		);
+
+		injectContextMenu(
+			'copy-link-searchcontextmenu',
+			'MessageSearchResultContextMenu',
+			contextMenuFunc,
+		)
 
 		inject('copy-link-dotmenu', MessageMenuItems, 'copyLink', args => {
 			clipboard.copy(getURL(args[0], args[1]));

--- a/index.js
+++ b/index.js
@@ -10,7 +10,10 @@ module.exports = class ViewRaw extends Plugin {
 
 	pluginWillUnload() {
 		uninject('copy-link-contextmenu');
-		uninject('copy-link-searchcontextmenu');
+		uninject('copy-link-search-contextmenu');
+		uninject('copy-link-text-contextmenu');
+		uninject('copy-link-thread-contextmenu');
+		uninject('copy-link-voice-contextmenu');
 		uninject('copy-link-dotmenu');
 	}
 
@@ -52,10 +55,28 @@ module.exports = class ViewRaw extends Plugin {
 		);
 
 		injectContextMenu(
-			'copy-link-searchcontextmenu',
+			'copy-link-search-contextmenu',
 			'MessageSearchResultContextMenu',
 			contextMenuFunc,
-		)
+		);
+
+		injectContextMenu(
+			'copy-link-text-contextmenu',
+			'ChannelListTextChannelContextMenu',
+			contextMenuFunc,
+		);
+
+		injectContextMenu(
+			'copy-link-thread-contextmenu',
+			'ChannelListThreadContextMenu',
+			contextMenuFunc,
+		);
+
+		injectContextMenu(
+			'copy-link-voice-contextmenu',
+			'ChannelListVoiceChannelContextMenu',
+			contextMenuFunc,
+		);
 
 		inject('copy-link-dotmenu', MessageMenuItems, 'copyLink', args => {
 			clipboard.copy(getURL(args[0], args[1]));


### PR DESCRIPTION
Fixes the copy link button in the search context menu

Example:

![DiscordCanary_X6PFLrrGbe](https://user-images.githubusercontent.com/44045823/184283540-ae2130b5-b14e-4f81-ad58-3324a08ff1be.png)

Also fixes the "copy link" button for channels in the channel list.

Let me know if there's any style or formatting suggestions. Javascript is not my main language.