### PR TITLE
fix clipboard module

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = class ViewRaw extends Plugin {
 	}
 
 	async run() {
-		const {clipboard} = await getModule(['clipboard']);
+		const {clipboard} = await getModule(['clipboard', 'crashReporter']);
 		const MessageMenuItems = await getModule(['copyLink', 'pinMessage']);
 
 		function checkChildren(el, url) {


### PR DESCRIPTION
previously it returned a string array instead of the clipboard functions:
![image](https://user-images.githubusercontent.com/55899582/184934127-e25f8f43-5664-422c-bbab-187272d9698e.png)
